### PR TITLE
bugfix for `ERR_STREAM_PREMATURE_CLOSE` issue

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get install -y \
     npm
 RUN npm install npm@latest -g && \
     npm install n -g && \
-    n latest
+    n 16.13.0
 RUN YARN_CHECKSUM_BEHAVIOR=update yarn && yarn build:www
 RUN npm install -g serve
 


### PR DESCRIPTION
The `latest` nodejs version using `n` is now 17, which breaks during yarn install step with problems similar to https://github.com/yarnpkg/berry/issues/3597. The `n lts` version today is `16.13.0` so using that fixed version here instead. 