### PR TITLE
cleaning up refs to `polkadot_launch` dir (old name with underscore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@
 
 scripts/kylin-data-proxy.env
 scripts/kylin_db/
-scripts/polkadot_launch/rococo*.json
+scripts/polkadot-launch/rococo*.json
 cumulus-parachain/*

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The `polkadot-launch` utility allows you to launch your network seamlessly by pr
 
   Once we have the `polkadot-launch` utility installed, we need to define the configuration file.
 
-  A configuration file has been provided within the repository at `scrips/polkadot_launch/kylinLaunchConfig.json`. You can customize it based on your requirements.
+  A configuration file has been provided within the repository at `scripts/polkadot-launch/kylinLaunchConfig.json`. You can customize it based on your requirements.
 
   - There are two sections in the file which are essential: `relaychain` and `parachains` 
   - relaychain: 3 key parameters
@@ -132,7 +132,7 @@ The `polkadot-launch` utility allows you to launch your network seamlessly by pr
 - #### Launch the network
 
 ```bash
-polkadot-launch scripts/polkadot_launch/kylinLaunchConfig.json
+polkadot-launch scripts/polkadot-launch/kylinLaunchConfig.json
 ```
 
 If the launch is successful, you will see:


### PR DESCRIPTION
the `polkadot_launch` directory was [recently changed](https://github.com/Kylin-Network/kylin-collator/commit/917c4621a31af196603b8129870971564971b31f#diff-0d52ab5c6ec44544ea1699bdfe124fae4f5047c3b1b6c789417c2b55cb3b3d32L10) to `polkadot-launch` which affected the README and .gitignore files. This just updates those to point to the new name.